### PR TITLE
feat!: rename permissions to {domain}_{action} convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-02-20
+
+### Changed
+
+- **BREAKING: Permission naming convention** — Renamed all built-in permission enum members from `{domain}s_management_{action}` to `{domain}_{action}` for consistency with downstream applications:
+  - `users_management_create/read/update/delete` → `user_create/read/update/delete`
+  - `roles_management_create/read/update/delete` → `role_create/read/update/delete`
+  - `permissions_management_create/read/update/delete` → `permission_create/read/update/delete`
+  - `password_management_update` removed — admin password endpoint now uses `user_update`
+- Updated documentation examples to reflect new `{domain}_{action}` naming convention.
+
 ## [1.3.2] - 2026-01-26
 
 ### Fixed

--- a/docs/handbook/docs/writing-endpoints.md
+++ b/docs/handbook/docs/writing-endpoints.md
@@ -69,7 +69,7 @@ from kwik.dependencies import has_permission
 @projects_router.get(
     "/",
     response_model=Paginated[ProjectProfile],
-    dependencies=(has_permission(Permissions.projects_management_read),),
+    dependencies=(has_permission(Permissions.project_read),),
 )
 def read_projects(q: ListQuery, context: UserContext) -> Paginated[ProjectProfile]:
     ...
@@ -80,7 +80,7 @@ Multiple permissions can be checked at once:
 ```python
 @projects_router.post(
     "/{project_id}/archive",
-    dependencies=(has_permission(Permissions.projects_management_update, Permissions.projects_management_read),),
+    dependencies=(has_permission(Permissions.project_update, Permissions.project_read),),
 )
 def archive_project(...):
     ...
@@ -93,10 +93,10 @@ System permission names live in `src/kwik/core/enum.py` as the `Permissions` enu
 ```python
 class Permissions(StrEnum):
     # ...existing entries
-    projects_management_create = "projects_management_create"
-    projects_management_read = "projects_management_read"
-    projects_management_update = "projects_management_update"
-    projects_management_delete = "projects_management_delete"
+    project_create = "project_create"
+    project_read = "project_read"
+    project_update = "project_update"
+    project_delete = "project_delete"
 ```
 
 Ensure your seeds/migrations create these permissions so roles can grant them.
@@ -152,7 +152,7 @@ Example:
 from kwik.core.enum import Permissions
 from kwik.dependencies import has_permission
 
-dependencies=(has_permission(Permissions.projects_management_read),)
+dependencies=(has_permission(Permissions.project_read),)
 ```
 
 ### ListQuery (pagination, sorting, filters)
@@ -245,7 +245,7 @@ projects_router = AuthenticatedRouter(prefix="/projects")
 @projects_router.get(
     "/",
     response_model=Paginated[ProjectProfile],
-    dependencies=(has_permission(Permissions.projects_management_read),),
+    dependencies=(has_permission(Permissions.project_read),),
 )
 def read_projects(q: ListQuery, context: UserContext) -> Paginated[ProjectProfile]:
     total, data = crud_projects.get_multi(context=context, **q)
@@ -254,7 +254,7 @@ def read_projects(q: ListQuery, context: UserContext) -> Paginated[ProjectProfil
 @projects_router.post(
     "/",
     response_model=ProjectProfile,
-    dependencies=(has_permission(Permissions.projects_management_create),),
+    dependencies=(has_permission(Permissions.project_create),),
 )
 def create_project(project_in: ProjectDefinition, context: UserContext) -> Project:
     existing = crud_projects.get_by_name(name=project_in.name, context=context)
@@ -265,7 +265,7 @@ def create_project(project_in: ProjectDefinition, context: UserContext) -> Proje
 @projects_router.get(
     "/{project_id}",
     response_model=ProjectProfile,
-    dependencies=(has_permission(Permissions.projects_management_read),),
+    dependencies=(has_permission(Permissions.project_read),),
 )
 def read_project(project_id: int, context: UserContext) -> Project:
     return crud_projects.get_if_exist(entity_id=project_id, context=context)
@@ -273,14 +273,14 @@ def read_project(project_id: int, context: UserContext) -> Project:
 @projects_router.put(
     "/{project_id}",
     response_model=ProjectProfile,
-    dependencies=(has_permission(Permissions.projects_management_update),),
+    dependencies=(has_permission(Permissions.project_update),),
 )
 def update_project(project_id: int, project_in: ProjectUpdate, context: UserContext) -> Project:
     return crud_projects.update(entity_id=project_id, obj_in=project_in, context=context)
  @projects_router.delete(
      "/{project_id}",
      response_model=ProjectProfile,
-     dependencies=(has_permission(Permissions.projects_management_delete),),
+     dependencies=(has_permission(Permissions.project_delete),),
  )
  def delete_project(project_id: int, context: UserContext) -> Project:
      return crud_projects.delete(entity_id=project_id, context=context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kwik"
-version = "1.3.2"
+version = "1.4.0"
 description = "Fast, batteries-included, business-oriented, opinionated REST APIs framework"
 readme = "README.md"
 authors = [

--- a/src/kwik/api/endpoints/permissions.py
+++ b/src/kwik/api/endpoints/permissions.py
@@ -20,7 +20,7 @@ permissions_router = AuthenticatedRouter(prefix="/permissions")
 @permissions_router.get(
     "/",
     response_model=Paginated[PermissionProfile],
-    dependencies=(has_permission(Permissions.permissions_management_read),),
+    dependencies=(has_permission(Permissions.permission_read),),
 )
 def read_permissions(q: ListQuery, context: UserContext) -> Paginated[PermissionProfile]:
     """Retrieve permissions."""
@@ -31,7 +31,7 @@ def read_permissions(q: ListQuery, context: UserContext) -> Paginated[Permission
 @permissions_router.post(
     "/",
     response_model=PermissionProfile,
-    dependencies=(has_permission(Permissions.permissions_management_create),),
+    dependencies=(has_permission(Permissions.permission_create),),
 )
 def create_permission(permission_in: PermissionDefinition, context: UserContext) -> Permission:
     """Create new permission."""
@@ -45,7 +45,7 @@ def create_permission(permission_in: PermissionDefinition, context: UserContext)
 @permissions_router.get(
     "/{permission_id}",
     response_model=PermissionProfile,
-    dependencies=(has_permission(Permissions.permissions_management_read),),
+    dependencies=(has_permission(Permissions.permission_read),),
 )
 def read_permission_by_id(permission_id: int, context: UserContext) -> Permission:
     """Get a specific permission by id."""
@@ -55,7 +55,7 @@ def read_permission_by_id(permission_id: int, context: UserContext) -> Permissio
 @permissions_router.put(
     "/{permission_id}",
     response_model=PermissionProfile,
-    dependencies=(has_permission(Permissions.permissions_management_update),),
+    dependencies=(has_permission(Permissions.permission_update),),
 )
 def update_permission(permission_id: int, permission_in: PermissionUpdate, context: UserContext) -> Permission:
     """Update a permission."""
@@ -67,8 +67,8 @@ def update_permission(permission_id: int, permission_in: PermissionUpdate, conte
     response_model=list[RoleProfile],
     dependencies=(
         has_permission(
-            Permissions.permissions_management_read,
-            Permissions.roles_management_read,
+            Permissions.permission_read,
+            Permissions.role_read,
         ),
     ),
 )
@@ -83,8 +83,8 @@ def read_roles_by_permission(permission_id: int, context: UserContext) -> list[R
     response_model=list[RoleProfile],
     dependencies=(
         has_permission(
-            Permissions.permissions_management_read,
-            Permissions.roles_management_read,
+            Permissions.permission_read,
+            Permissions.role_read,
         ),
     ),
 )
@@ -97,7 +97,7 @@ def read_available_roles_for_permission(permission_id: int, context: UserContext
 @permissions_router.delete(
     "/{permission_id}/roles",
     response_model=PermissionProfile,
-    dependencies=(has_permission(Permissions.permissions_management_delete),),
+    dependencies=(has_permission(Permissions.permission_delete),),
 )
 def purge_all_roles(permission_id: int, context: UserContext) -> Permission:
     """
@@ -109,7 +109,7 @@ def purge_all_roles(permission_id: int, context: UserContext) -> Permission:
         NotFound: If the provided permission does not exist
 
     Permissions required:
-        * `permissions_management_delete`
+        * `permission_delete`
 
     """
     return crud_permissions.purge_all_roles(permission_id=permission_id, context=context)
@@ -118,7 +118,7 @@ def purge_all_roles(permission_id: int, context: UserContext) -> Permission:
 @permissions_router.delete(
     "/{permission_id}",
     response_model=PermissionProfile,
-    dependencies=(has_permission(Permissions.permissions_management_delete),),
+    dependencies=(has_permission(Permissions.permission_delete),),
 )
 def delete_permission(permission_id: int, context: UserContext) -> Permission:
     """
@@ -128,7 +128,7 @@ def delete_permission(permission_id: int, context: UserContext) -> Permission:
         NotFound: If the provided permission does not exist
 
     Permissions required:
-        * `permissions_management_delete`
+        * `permission_delete`
 
     """
     return crud_permissions.delete(entity_id=permission_id, context=context)

--- a/src/kwik/api/endpoints/roles.py
+++ b/src/kwik/api/endpoints/roles.py
@@ -29,7 +29,7 @@ roles_router = AuthenticatedRouter(prefix="/roles")
 @roles_router.get(
     "/",
     response_model=Paginated[RoleProfile],
-    dependencies=(has_permission(Permissions.roles_management_read),),
+    dependencies=(has_permission(Permissions.role_read),),
 )
 def read_roles(q: ListQuery, context: UserContext) -> Paginated[RoleProfile]:
     """Retrieve roles."""
@@ -40,7 +40,7 @@ def read_roles(q: ListQuery, context: UserContext) -> Paginated[RoleProfile]:
 @roles_router.post(
     "/",
     response_model=RoleProfile,
-    dependencies=(has_permission(Permissions.roles_management_create),),
+    dependencies=(has_permission(Permissions.role_create),),
 )
 def create_role(role_in: RoleDefinition, context: UserContext) -> Role:
     """Create new role."""
@@ -54,7 +54,7 @@ def create_role(role_in: RoleDefinition, context: UserContext) -> Role:
 @roles_router.get(
     "/{role_id}",
     response_model=RoleProfile,
-    dependencies=(has_permission(Permissions.roles_management_read),),
+    dependencies=(has_permission(Permissions.role_read),),
 )
 def read_role_by_id(role_id: int, context: UserContext) -> Role:
     """Get a specific role by id."""
@@ -64,7 +64,7 @@ def read_role_by_id(role_id: int, context: UserContext) -> Role:
 @roles_router.put(
     "/{role_id}",
     response_model=RoleProfile,
-    dependencies=(has_permission(Permissions.roles_management_update),),
+    dependencies=(has_permission(Permissions.role_update),),
 )
 def update_role(role_id: int, role_in: RoleUpdate, context: UserContext) -> Role:
     """Update a role."""
@@ -74,7 +74,7 @@ def update_role(role_id: int, role_in: RoleUpdate, context: UserContext) -> Role
 @roles_router.delete(
     "/{role_id}",
     response_model=RoleProfile,
-    dependencies=(has_permission(Permissions.roles_management_delete),),
+    dependencies=(has_permission(Permissions.role_delete),),
 )
 def delete_role(role_id: int, context: UserContext) -> Role:
     """Delete a role."""
@@ -87,8 +87,8 @@ def delete_role(role_id: int, context: UserContext) -> Role:
     response_model=list[PermissionProfile],
     dependencies=(
         has_permission(
-            Permissions.roles_management_read,
-            Permissions.permissions_management_read,
+            Permissions.role_read,
+            Permissions.permission_read,
         ),
     ),
 )
@@ -103,8 +103,8 @@ def read_permissions_by_role(role_id: int, context: UserContext) -> list[Permiss
     response_model=list[PermissionProfile],
     dependencies=(
         has_permission(
-            Permissions.roles_management_read,
-            Permissions.permissions_management_read,
+            Permissions.role_read,
+            Permissions.permission_read,
         ),
     ),
 )
@@ -119,8 +119,8 @@ def read_available_permissions_for_role(role_id: int, context: UserContext) -> l
     response_model=list[UserProfile],
     dependencies=(
         has_permission(
-            Permissions.users_management_read,
-            Permissions.roles_management_read,
+            Permissions.user_read,
+            Permissions.role_read,
         ),
     ),
 )
@@ -135,8 +135,8 @@ def users_with_role(role_id: int, context: UserContext) -> list[User]:
     response_model=list[UserProfile],
     dependencies=(
         has_permission(
-            Permissions.users_management_read,
-            Permissions.roles_management_read,
+            Permissions.user_read,
+            Permissions.role_read,
         ),
     ),
 )
@@ -150,8 +150,8 @@ def available_users_for_role(role_id: int, context: UserContext) -> list[User]:
     response_model=RoleProfile,
     dependencies=(
         has_permission(
-            Permissions.roles_management_update,
-            Permissions.permissions_management_update,
+            Permissions.role_update,
+            Permissions.permission_update,
         ),
     ),
 )
@@ -163,8 +163,8 @@ def assign_permission_to_role(role_id: int, assignment: RolePermissionAssignment
         NotFound: If the provided role or permission does not exist
 
     Permissions required:
-        * `roles_management_update`
-        * `permissions_management_update`
+        * `role_update`
+        * `permission_update`
 
     """
     role = crud_roles.get_if_exist(entity_id=role_id, context=context)
@@ -177,8 +177,8 @@ def assign_permission_to_role(role_id: int, assignment: RolePermissionAssignment
     response_model=RoleProfile,
     dependencies=(
         has_permission(
-            Permissions.roles_management_update,
-            Permissions.permissions_management_update,
+            Permissions.role_update,
+            Permissions.permission_update,
         ),
     ),
 )
@@ -190,8 +190,8 @@ def remove_permission_from_role(role_id: int, permission_id: int, context: UserC
         NotFound: If the provided role or permission does not exist
 
     Permissions required:
-        * `roles_management_update`
-        * `permissions_management_update`
+        * `role_update`
+        * `permission_update`
 
     """
     role = crud_roles.get_if_exist(entity_id=role_id, context=context)
@@ -204,8 +204,8 @@ def remove_permission_from_role(role_id: int, permission_id: int, context: UserC
     response_model=RoleProfile,
     dependencies=(
         has_permission(
-            Permissions.roles_management_update,
-            Permissions.users_management_update,
+            Permissions.role_update,
+            Permissions.user_update,
         ),
     ),
 )
@@ -217,8 +217,8 @@ def assign_user_to_role(role_id: int, assignment: RoleUserAssignment, context: U
         NotFound: If the provided role or user does not exist
 
     Permissions required:
-        * `roles_management_update`
-        * `users_management_update`
+        * `role_update`
+        * `user_update`
 
     """
     role = crud_roles.get_if_exist(entity_id=role_id, context=context)
@@ -231,8 +231,8 @@ def assign_user_to_role(role_id: int, assignment: RoleUserAssignment, context: U
     response_model=RoleProfile,
     dependencies=(
         has_permission(
-            Permissions.roles_management_update,
-            Permissions.users_management_update,
+            Permissions.role_update,
+            Permissions.user_update,
         ),
     ),
 )
@@ -244,8 +244,8 @@ def remove_user_from_role(role_id: int, user_id: int, context: UserContext) -> R
         NotFound: If the provided role or user does not exist
 
     Permissions required:
-        * `roles_management_update`
-        * `users_management_update`
+        * `role_update`
+        * `user_update`
 
     """
     role = crud_roles.get_if_exist(entity_id=role_id, context=context)
@@ -258,8 +258,8 @@ def remove_user_from_role(role_id: int, user_id: int, context: UserContext) -> R
     response_model=RoleProfile,
     dependencies=(
         has_permission(
-            Permissions.roles_management_delete,
-            Permissions.permissions_management_delete,
+            Permissions.role_delete,
+            Permissions.permission_delete,
         ),
     ),
 )
@@ -273,8 +273,8 @@ def remove_all_permissions_from_role(role_id: int, context: UserContext) -> Role
         NotFound: If the provided role does not exist
 
     Permissions required:
-        * `roles_management_delete`
-        * `permissions_management_delete`
+        * `role_delete`
+        * `permission_delete`
 
     """
     role = crud_roles.get_if_exist(entity_id=role_id, context=context)
@@ -286,8 +286,8 @@ def remove_all_permissions_from_role(role_id: int, context: UserContext) -> Role
     response_model=RoleProfile,
     dependencies=(
         has_permission(
-            Permissions.roles_management_delete,
-            Permissions.users_management_delete,
+            Permissions.role_delete,
+            Permissions.user_delete,
         ),
     ),
 )
@@ -301,8 +301,8 @@ def remove_all_users_from_role(role_id: int, context: UserContext) -> Role:
         NotFound: If the provided role does not exist
 
     Permissions required:
-        * `roles_management_delete`
-        * `users_management_delete`
+        * `role_delete`
+        * `user_delete`
 
     """
     role = crud_roles.get_if_exist(entity_id=role_id, context=context)

--- a/src/kwik/api/endpoints/users.py
+++ b/src/kwik/api/endpoints/users.py
@@ -28,7 +28,7 @@ users_router = AuthenticatedRouter(prefix="/users")
 @users_router.get(
     "/",
     response_model=Paginated[UserProfile],
-    dependencies=(has_permission(Permissions.users_management_read),),
+    dependencies=(has_permission(Permissions.user_read),),
 )
 def read_users(q: ListQuery, context: UserContext) -> Paginated[UserProfile]:
     """Retrieve users."""
@@ -39,7 +39,7 @@ def read_users(q: ListQuery, context: UserContext) -> Paginated[UserProfile]:
 @users_router.post(
     "/",
     response_model=UserProfile,
-    dependencies=(has_permission(Permissions.users_management_create),),
+    dependencies=(has_permission(Permissions.user_create),),
 )
 def create_user(user_in: UserRegistration, context: UserContext) -> User:
     """Create new user."""
@@ -83,7 +83,7 @@ def update_my_password(user: current_user, obj_in: UserPasswordChange, context: 
 @users_router.get(
     "/{user_id}",
     response_model=UserProfile,
-    dependencies=(has_permission(Permissions.users_management_read),),
+    dependencies=(has_permission(Permissions.user_read),),
 )
 def read_user_by_id(user_id: int, context: UserContext) -> User:
     """Get a specific user by id."""
@@ -93,7 +93,7 @@ def read_user_by_id(user_id: int, context: UserContext) -> User:
 @users_router.put(
     "/{user_id}",
     response_model=UserProfile,
-    dependencies=(has_permission(Permissions.users_management_update),),
+    dependencies=(has_permission(Permissions.user_update),),
 )
 def update_user(user_id: int, user_in: UserProfileUpdate, context: UserContext) -> User:
     """Update a user."""
@@ -104,8 +104,8 @@ def update_user(user_id: int, user_in: UserProfileUpdate, context: UserContext) 
     "/{user_id}/permissions",
     response_model=list[PermissionProfile],
     dependencies=(
-        has_permission(Permissions.users_management_read),
-        has_permission(Permissions.permissions_management_read),
+        has_permission(Permissions.user_read),
+        has_permission(Permissions.permission_read),
     ),
 )
 def read_user_permissions(user_id: int, context: UserContext) -> list[Permission]:
@@ -119,8 +119,8 @@ def read_user_permissions(user_id: int, context: UserContext) -> list[Permission
     response_model=list[RoleProfile],
     dependencies=(
         has_permission(
-            Permissions.users_management_read,
-            Permissions.roles_management_read,
+            Permissions.user_read,
+            Permissions.role_read,
         ),
     ),
 )
@@ -133,7 +133,7 @@ def read_user_roles(user_id: int, context: UserContext) -> list[Role]:
 @users_router.put(
     "/{user_id}/password",
     response_model=UserProfile,
-    dependencies=(has_permission(Permissions.password_management_update),),
+    dependencies=(has_permission(Permissions.user_update),),
 )
 def update_password(user_id: int, obj_in: UserPasswordChange, context: UserContext) -> User:
     """Update user's password (admin operation)."""

--- a/src/kwik/core/enum.py
+++ b/src/kwik/core/enum.py
@@ -14,19 +14,17 @@ class Permissions(StrEnum):
 
     impersonification = "impersonification"
 
-    users_management_create = "users_management_create"
-    users_management_read = "users_management_read"
-    users_management_update = "users_management_update"
-    users_management_delete = "users_management_delete"
+    user_create = "user_create"
+    user_read = "user_read"
+    user_update = "user_update"
+    user_delete = "user_delete"
 
-    permissions_management_create = "permissions_management_create"
-    permissions_management_read = "permissions_management_read"
-    permissions_management_update = "permissions_management_update"
-    permissions_management_delete = "permissions_management_delete"
+    permission_create = "permission_create"
+    permission_read = "permission_read"
+    permission_update = "permission_update"
+    permission_delete = "permission_delete"
 
-    roles_management_create = "roles_management_create"
-    roles_management_read = "roles_management_read"
-    roles_management_update = "roles_management_update"
-    roles_management_delete = "roles_management_delete"
-
-    password_management_update = "password_management_update"  # noqa: S105
+    role_create = "role_create"
+    role_read = "role_read"
+    role_update = "role_update"
+    role_delete = "role_delete"

--- a/tests/crud/test_crud_permissions.py
+++ b/tests/crud/test_crud_permissions.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from kwik.core.enum import Permissions
 from kwik.crud import UserCtx, crud_permissions, crud_roles
 from kwik.exceptions import DuplicatedEntityError, EntityNotFoundError
 from kwik.schemas import PermissionDefinition, PermissionUpdate
@@ -109,7 +110,7 @@ class TestPermissionCRUD:
 
     def test_get_multi_permissions(self, admin_context: UserCtx) -> None:
         """Test getting multiple permissions with pagination."""
-        total_permissions = 14  # All permissions from Permissions enum are associated with admin_user
+        total_permissions = len(Permissions)
         page_limit = 5
 
         # Test first page

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ wheels = [
 
 [[package]]
 name = "kwik"
-version = "1.3.2"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Renamed all built-in permission enum members from `{domain}s_management_{action}` to `{domain}_{action}`
- Removed `password_management_update` — admin password endpoint now uses `user_update`
- Updated all router files, docstrings, and documentation to match
- Bumped version to `1.4.0`

## BREAKING CHANGE

Permission enum members renamed:
- `users_management_*` → `user_*`
- `roles_management_*` → `role_*`
- `permissions_management_*` → `permission_*`
- `password_management_update` removed (use `user_update`)

## Test plan

- [x] All 446 kwik tests pass (96% coverage)
- [x] Ruff lint + format clean
- [x] No remaining `_management_` strings in source or docs
- [x] Test fixture dynamically seeds permissions via `len(Permissions)`