### PR TITLE
feat: add authenticate_from_token + bump v1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kwik"
-version = "1.4.0"
+version = "1.5.0"
 description = "Fast, batteries-included, business-oriented, opinionated REST APIs framework"
 readme = "README.md"
 authors = [

--- a/src/kwik/security.py
+++ b/src/kwik/security.py
@@ -13,6 +13,9 @@ from kwik import schemas
 from kwik.exceptions.base import TokenValidationError
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from kwik.models import User
     from kwik.settings import BaseKwikSettings
 
 ALGORITHM: Final[str] = "HS256"
@@ -78,3 +81,42 @@ def verify_password_reset_token(token: str, settings: BaseKwikSettings) -> str |
     """Verify password reset token and return email if valid."""
     decoded_token = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
     return decoded_token.get("sub", None)
+
+
+def authenticate_from_token(
+    *,
+    token: str,
+    settings: BaseKwikSettings,
+    session: Session,
+) -> User:
+    """
+    Validate a JWT token and return the corresponding user.
+
+    Convenience function for authenticating outside FastAPI's dependency injection
+    (e.g., SSE endpoints, Celery tasks, CLI scripts).
+
+    Args:
+        token: Raw JWT string.
+        settings: Application settings (provides SECRET_KEY and ALGORITHM).
+        session: SQLAlchemy session for user lookup.
+
+    Returns:
+        The authenticated User ORM object.
+
+    Raises:
+        AccessDeniedError: If the token is invalid or the user does not exist.
+
+    """
+    # Local imports to avoid circular dependency: crud.users imports security for hashing
+    from kwik.crud import crud_users  # noqa: PLC0415
+    from kwik.crud.context import Context  # noqa: PLC0415
+    from kwik.exceptions import AccessDeniedError  # noqa: PLC0415
+
+    payload = decode_token(token=token, settings=settings)
+    if payload.sub is None:
+        raise AccessDeniedError
+    context = Context(session=session, user=None)
+    user = crud_users.get(entity_id=int(payload.sub), context=context)
+    if user is None:
+        raise AccessDeniedError
+    return user

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ wheels = [
 
 [[package]]
 name = "kwik"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Add `authenticate_from_token(*, token, settings, session) -> User` convenience function to `kwik.security`
- Enables JWT authentication outside FastAPI's dependency injection (SSE endpoints, Celery tasks, CLI scripts)
- Bump version to 1.5.0

## Test plan
- [x] All 15 security tests pass
- [x] Ruff checks pass