### PR TITLE
feat: add user_count to RoleProfile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kwik"
-version = "1.5.0"
+version = "1.6.0"
 description = "Fast, batteries-included, business-oriented, opinionated REST APIs framework"
 readme = "README.md"
 authors = [

--- a/src/kwik/models/user.py
+++ b/src/kwik/models/user.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy import Boolean, ForeignKey, String, func, select
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 
 from .base import Base
 from .mixins import RecordInfoMixin
@@ -71,6 +71,12 @@ class UserRole(Base, RecordInfoMixin):
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), nullable=False)
+
+
+# Deferred column_property: must be defined after UserRole to avoid forward reference.
+Role.user_count = column_property(
+    select(func.count(UserRole.id)).where(UserRole.role_id == Role.id).correlate_except(UserRole).scalar_subquery()
+)
 
 
 class Permission(Base, RecordInfoMixin):

--- a/src/kwik/schemas/role.py
+++ b/src/kwik/schemas/role.py
@@ -36,6 +36,7 @@ class RoleProfile(ORMMixin):
 
     name: _RoleName
     is_active: bool
+    user_count: int
 
 
 class RolePermissionAssignment(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ wheels = [
 
 [[package]]
 name = "kwik"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Add `user_count` column_property on the `Role` model via a correlated subquery on `users_roles`
- Add `user_count: int` field to `RoleProfile` schema — serialized automatically via `from_attributes=True`
- Bump version to 1.6.0

The count is computed inline in every `select(Role)` query with no N+1 overhead. Useful for admin UIs that display how many users are assigned to each role.

## Test plan
- All 446 existing tests pass (including roles CRUD + API tests)
- `ruff check` and `ruff format --check` pass